### PR TITLE
fix check for www redirection, using a site that has www

### DIFF
--- a/data/tests/test_check_website.py
+++ b/data/tests/test_check_website.py
@@ -199,7 +199,7 @@ def test_http_www_redirect_nok(http_server, force_all_to_localhost):
 
 def test_https_www_redirect_ok(http_server):
     """Test a site that redirects its www correctly"""
-    issues = check_website("https://www.anct.gouv.fr/")
+    issues = check_website("https://www.sante.gouv.fr/")
     assert Issues.WEBSITE_HTTPS_NOWWW not in issues
 
 


### PR DESCRIPTION
Currently CI checks are failing because www.anct.gouv.fr does not respond on port 443. Use a site that has the www DNS record, that does accept connections on port 443, and that does redirect correctly.