### PR TITLE
Update ContactUs.tsx

### DIFF
--- a/src/components/ContactUs.tsx
+++ b/src/components/ContactUs.tsx
@@ -45,8 +45,8 @@ export default function ContactUs() {
         </p>
         <p>
           Écrivez-nous à{" "}
-          <Link href="mailto:lasuiteterritoriale@anct.gouv.fr" className={fr.cx("fr-link")}>
-            lasuiteterritoriale@anct.gouv.fr
+          <Link href="mailto:contact@suite.anct.gouv.fr" className={fr.cx("fr-link")}>
+            contact@suite.anct.gouv.fr
           </Link>
         </p>
       </div>


### PR DESCRIPTION
Updated the contact email address displayed on the website.
Old address: suiteterritoriale@anct.gouv.fr
New address: contact@suite.anct.gouv.fr