### PR TITLE
🐛(deploymap) only display visible services in commune services list

### DIFF
--- a/src/components/map/features/deploiement/SidePanelContent.jsx
+++ b/src/components/map/features/deploiement/SidePanelContent.jsx
@@ -415,21 +415,27 @@ const serviceDetails = (service, stats, compact = false) => {
     );
   };
 
-  const communeInfo = () => (
-    <div>
-      <h3 className={styles.serviceListTitle}>Services</h3>
-      {mapState.selectedAreas?.city?.additionalCityStats?.all_services && (
-        services.map((service) => {
-          const cityServices = mapState.selectedAreas.city.additionalCityStats.all_services;
-          const isUsed = service._mergedIds
+  const communeInfo = () => {
+    const cityServices = mapState.selectedAreas?.city?.additionalCityStats?.all_services;
+    const visibleUsedServices = cityServices
+      ? services.filter((service) => {
+          const config = servicesConfig[service.name];
+          if (!resolveVisible(config)) return false;
+          return service._mergedIds
             ? service._mergedIds.some(id => cityServices.includes(id))
             : cityServices.includes(service.id);
-          if (!isUsed) {
-            return null;
-          }
-          return (
+        })
+      : [];
+
+    return (
+      <div>
+        <h3 className={styles.serviceListTitle}>Services</h3>
+        {visibleUsedServices.length === 0 ? (
+          <p style={{ fontSize: '0.875rem', color: 'var(--text-mention-grey)' }}>Aucun service utilisé par cette structure.</p>
+        ) : (
+          visibleUsedServices.map((service) => (
             <div key={service.id} className={styles.cityServiceItem}>
-              <img src={service.logo_url} alt={service.name} style={{ width: "18px", height: "18px", marginRight: "0.4rem" }} />
+              {service.logo_url && <img src={service.logo_url} alt={service.name} style={{ width: "18px", height: "18px", marginRight: "0.4rem" }} />}
               <span style={{ fontSize: "0.875rem" }}>{service.name}&nbsp;</span>
               {service.maturity !== 'stable' && (
                 <span className={fr.cx("fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon")}>
@@ -437,11 +443,11 @@ const serviceDetails = (service, stats, compact = false) => {
                 </span>
               )}
             </div>
-          );
-        })
-      )}
-    </div>
-  );
+          ))
+        )}
+      </div>
+    );
+  };
 
   const areaOrgServices = () => (
     <div>

--- a/src/components/map/features/deploiement/SidePanelContent.jsx
+++ b/src/components/map/features/deploiement/SidePanelContent.jsx
@@ -449,22 +449,22 @@ const serviceDetails = (service, stats, compact = false) => {
     );
   };
 
-  const areaOrgServices = () => (
-    <div>
-      <h3 className={styles.serviceListTitle}>Services</h3>
-      {services.filter(service =>
-        service._mergedIds
-          ? service._mergedIds.some(id => selectedAreaOwnServices.has(id))
-          : selectedAreaOwnServices.has(service.id)
-      ).length === 0 ? (
-        <p style={{ fontSize: '0.875rem', color: 'var(--text-mention-grey)' }}>Aucun service utilisé par cette structure.</p>
-      ) : (
-        services.map((service) => {
-          const isUsed = service._mergedIds
-            ? service._mergedIds.some(id => selectedAreaOwnServices.has(id))
-            : selectedAreaOwnServices.has(service.id);
-          if (!isUsed) return null;
-          return (
+  const areaOrgServices = () => {
+    const visibleUsedServices = services.filter((service) => {
+      const config = servicesConfig[service.name];
+      if (!resolveVisible(config)) return false;
+      return service._mergedIds
+        ? service._mergedIds.some(id => selectedAreaOwnServices.has(id))
+        : selectedAreaOwnServices.has(service.id);
+    });
+
+    return (
+      <div>
+        <h3 className={styles.serviceListTitle}>Services</h3>
+        {visibleUsedServices.length === 0 ? (
+          <p style={{ fontSize: '0.875rem', color: 'var(--text-mention-grey)' }}>Aucun service utilisé par cette structure.</p>
+        ) : (
+          visibleUsedServices.map((service) => (
             <div key={service.id} className={styles.cityServiceItem}>
               {service.logo_url && <img src={service.logo_url} alt={service.name} style={{ width: "18px", height: "18px", marginRight: "0.4rem" }} />}
               <span style={{ fontSize: "0.875rem" }}>{service.name}&nbsp;</span>
@@ -474,11 +474,11 @@ const serviceDetails = (service, stats, compact = false) => {
                 </span>
               )}
             </div>
-          );
-        })
-      )}
-    </div>
-  );
+          ))
+        )}
+      </div>
+    );
+  };
 
   const header = () => (
     <div className={styles.header}>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,8 +1,8 @@
 import { and, asc, desc, eq, inArray, like, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
-import type { Commune } from "./schema";
 import { departmentsRegion } from "./departmentsRegion";
+import type { Commune } from "./schema";
 import * as schema from "./schema";
 import {
   operators,
@@ -245,7 +245,7 @@ export async function fetchPartenairesRegions(): Promise<PartenairesRegionResult
   const proConnectServiceIds = (
     await db.select({ id: services.id }).from(services).where(eq(services.type, "proconnect"))
   ).map(({ id }) => id);
-  
+
   const proConnectServiceIdsSql = sql.join(
     proConnectServiceIds.map((id) => sql`${id}`),
     sql`, `,
@@ -288,4 +288,3 @@ export async function fetchPartenairesRegions(): Promise<PartenairesRegionResult
 
   return results;
 }
-

--- a/src/lib/departmentsRegion.ts
+++ b/src/lib/departmentsRegion.ts
@@ -5,19 +5,47 @@ export type DepartmentsRegion = {
 };
 
 export const departmentsRegion: DepartmentsRegion[] = [
-  { name: "Auvergne-Rhône-Alpes", numDpt: ["01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"], isDrom: false },
-  { name: "Bourgogne-Franche-Comté", numDpt: ["21", "25", "39", "58", "70", "71", "89", "90"], isDrom: false },
+  {
+    name: "Auvergne-Rhône-Alpes",
+    numDpt: ["01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"],
+    isDrom: false,
+  },
+  {
+    name: "Bourgogne-Franche-Comté",
+    numDpt: ["21", "25", "39", "58", "70", "71", "89", "90"],
+    isDrom: false,
+  },
   { name: "Bretagne", numDpt: ["22", "29", "35", "56"], isDrom: false },
   { name: "Centre-Val de Loire", numDpt: ["18", "28", "36", "37", "41", "45"], isDrom: false },
   { name: "Corse", numDpt: ["2A", "2B"], isDrom: false },
-  { name: "Grand Est", numDpt: ["08", "10", "51", "52", "54", "55", "57", "67", "68", "88"], isDrom: false },
+  {
+    name: "Grand Est",
+    numDpt: ["08", "10", "51", "52", "54", "55", "57", "67", "68", "88"],
+    isDrom: false,
+  },
   { name: "Hauts-de-France", numDpt: ["02", "59", "60", "62", "80"], isDrom: false },
-  { name: "Île-de-France", numDpt: ["75", "77", "78", "91", "92", "93", "94", "95"], isDrom: false },
+  {
+    name: "Île-de-France",
+    numDpt: ["75", "77", "78", "91", "92", "93", "94", "95"],
+    isDrom: false,
+  },
   { name: "Normandie", numDpt: ["14", "27", "50", "61", "76"], isDrom: false },
-  { name: "Nouvelle-Aquitaine", numDpt: ["16", "17", "19", "23", "24", "33", "40", "47", "64", "79", "86", "87"], isDrom: false },
-  { name: "Occitanie", numDpt: ["09", "11", "12", "30", "31", "32", "34", "46", "48", "65", "66", "81", "82"], isDrom: false },
+  {
+    name: "Nouvelle-Aquitaine",
+    numDpt: ["16", "17", "19", "23", "24", "33", "40", "47", "64", "79", "86", "87"],
+    isDrom: false,
+  },
+  {
+    name: "Occitanie",
+    numDpt: ["09", "11", "12", "30", "31", "32", "34", "46", "48", "65", "66", "81", "82"],
+    isDrom: false,
+  },
   { name: "Pays de la Loire", numDpt: ["44", "49", "53", "72", "85"], isDrom: false },
-  { name: "Provence-Alpes-Côte d’Azur", numDpt: ["04", "05", "06", "13", "83", "84"], isDrom: false },
+  {
+    name: "Provence-Alpes-Côte d’Azur",
+    numDpt: ["04", "05", "06", "13", "83", "84"],
+    isDrom: false,
+  },
 
   // DROM
   { name: "Guadeloupe", numDpt: ["971"], isDrom: true },

--- a/src/pages/partenaires.tsx
+++ b/src/pages/partenaires.tsx
@@ -157,7 +157,7 @@ const FAQS = [
     answer: (
       <>
         <p>
-          <strong>Toute structure publiques de mutualisation</strong> qui accompagne les
+          <strong>Toute structure publique de mutualisation</strong> qui accompagne les
           collectivités dans leur transformation numérique est invitée à devenir partenaire de
           l'ANCT pour déployer les services de la Suite territoriale :
         </p>

--- a/src/pages/partenaires.tsx
+++ b/src/pages/partenaires.tsx
@@ -1,16 +1,16 @@
 import FaqList from "@/components/FaqList";
+import TrialContact from "@/components/TrialContact";
 import { fetchPartenairesRegions } from "@/lib/db";
+import { departmentsRegion } from "@/lib/departmentsRegion";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Accordion } from "@codegouvfr/react-dsfr/Accordion";
 import { Button } from "@codegouvfr/react-dsfr/Button";
-import TrialContact from "@/components/TrialContact";
-import { departmentsRegion } from "@/lib/departmentsRegion";
 
 import { GetServerSideProps, NextPage } from "next";
 
 import { NextSeo } from "next-seo";
-import Link from "next/link";
 import Image from "next/image";
+import Link from "next/link";
 
 type RegionItem = {
   name: string;
@@ -74,14 +74,18 @@ function OpsnItem({ item }: { item: RegionItem }) {
               "fr-badge--no-icon",
               item.status === "partenaire" || item.status === "partenaire_avec_services"
                 ? "fr-badge--success"
-                : "fr-badge--new"
+                : "fr-badge--new",
             )}
           >
-            {item.status === "partenaire" || item.status === "partenaire_avec_services" ? "Partenaire" : "À venir"}
+            {item.status === "partenaire" || item.status === "partenaire_avec_services"
+              ? "Partenaire"
+              : "À venir"}
           </span>
         ) : null}
         {item.hasProConnect ? (
-          <span className={fr.cx("fr-badge", "fr-badge--sm", "fr-badge--no-icon", "fr-badge--info")}>
+          <span
+            className={fr.cx("fr-badge", "fr-badge--sm", "fr-badge--no-icon", "fr-badge--info")}
+          >
             ProConnect
           </span>
         ) : null}
@@ -101,16 +105,20 @@ function NoOpsnItem({ isDrom }: { isDrom: boolean }) {
         gap: "1rem",
       }}
     >
-      <p className={fr.cx("fr-mb-0", isDrom ? "fr-pl-2w" : "fr-pl-0")}
-         style={{ color: "var(--text-mention-grey)" }}>
+      <p
+        className={fr.cx("fr-mb-0", isDrom ? "fr-pl-2w" : "fr-pl-0")}
+        style={{ color: "var(--text-mention-grey)" }}
+      >
         <em>Aucun partenaire pour le moment</em>
       </p>
-      <Link href="mailto:contact@suite.anct.gouv.fr" 
-            className={fr.cx("fr-link") + " no-underline opsn-item__link no-opsn-item__link"}
-            style={{ display: "inline-flex", width: "fit-content", alignItems: "center" }}
-            target="_blank" 
-            rel="noopener noreferrer">
-              Devenez partenaire
+      <Link
+        href="mailto:contact@suite.anct.gouv.fr"
+        className={fr.cx("fr-link") + " no-underline opsn-item__link no-opsn-item__link"}
+        style={{ display: "inline-flex", width: "fit-content", alignItems: "center" }}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Devenez partenaire
       </Link>
     </div>
   );
@@ -119,11 +127,24 @@ function NoOpsnItem({ isDrom }: { isDrom: boolean }) {
 const REF_INTRO = (
   <>
     <p>
-      L'Agence nationale de la cohésion des territoires est partenaire des opérateurs publics de services numériques (OPSN) du réseau <Link href="https://www.asso-declic.fr/" target="_blank">Déclic</Link> pour le déploiement de la Suite territoriale auprès des communes de moins de 3 500 habitants et des intercommunalités de moins de 15 000 habitants. 
+      L'Agence nationale de la cohésion des territoires est partenaire des opérateurs publics de
+      services numériques (OPSN) du réseau{" "}
+      <Link href="https://www.asso-declic.fr/" target="_blank">
+        Déclic
+      </Link>{" "}
+      pour le déploiement de la Suite territoriale auprès des communes de moins de 3 500 habitants
+      et des intercommunalités de moins de 15 000 habitants.
     </p>
     <p>
-    Cette page évolutive recense l’ensemble de nos partenaires au local. Vous êtes une structure publique (opérateurs publics de services numériques, centre de gestion, intercommunalités, etc.) qui offre des services numériques essentiels ?<br />
-      <Link href="mailto:contact@suite.anct.gouv.fr" className={fr.cx("fr-link")} target="_blank" rel="noopener noreferrer">
+      Cette page évolutive recense l’ensemble de nos partenaires au local. Vous êtes une structure
+      publique (opérateurs publics de services numériques, centre de gestion, intercommunalités,
+      etc.) qui offre des services numériques essentiels ?<br />
+      <Link
+        href="mailto:contact@suite.anct.gouv.fr"
+        className={fr.cx("fr-link")}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Contactez-nous pour être référencé
       </Link>
     </p>
@@ -136,12 +157,12 @@ const FAQS = [
     answer: (
       <>
         <p>
-          <strong>Toute structure publiques de mutualisation</strong> qui accompagne les collectivités dans leur transformation numérique est invitée à devenir partenaire de l'ANCT pour déployer les services de la Suite territoriale :
+          <strong>Toute structure publiques de mutualisation</strong> qui accompagne les
+          collectivités dans leur transformation numérique est invitée à devenir partenaire de
+          l'ANCT pour déployer les services de la Suite territoriale :
         </p>
         <ul>
-          <li>
-            Opérateurs Publics de Services Numériques (OPSN)
-          </li>
+          <li>Opérateurs Publics de Services Numériques (OPSN)</li>
           <li>Intercommunalités</li>
           <li>Centres de gestion de la fonction publique territoriale (CDG)</li>
           <li>Syndicats mixtes informatiques</li>
@@ -151,7 +172,9 @@ const FAQS = [
           <li>etc...</li>
         </ul>
         <p>
-          Ancrées dans les territoires, ces partenaires sont les relais de proximité essentiels pour déployer les services numériques souverains auprès des communes, en particulier les plus vulnérables, selon le principe de subsidiarité.
+          Ancrées dans les territoires, ces partenaires sont les relais de proximité essentiels pour
+          déployer les services numériques souverains auprès des communes, en particulier les plus
+          vulnérables, selon le principe de subsidiarité.
         </p>
       </>
     ),
@@ -161,17 +184,37 @@ const FAQS = [
     answer: (
       <>
         <p>
-          <strong>Oui, tous les acteurs de la filière du numérique française </strong> (hébergeurs, intégrateurs, éditeurs...) sont également des partenaires de l'ANCT, mobilisés pour concevoir, faire évoluer et déployer des services numériques souverains et interopérables auprès des territoires.
+          <strong>Oui, tous les acteurs de la filière du numérique française </strong> (hébergeurs,
+          intégrateurs, éditeurs...) sont également des partenaires de l'ANCT, mobilisés pour
+          concevoir, faire évoluer et déployer des services numériques souverains et interopérables
+          auprès des territoires.
         </p>
         <p>
-          <strong>Cette coopération public/privé permet la pleine complémentarité</strong> entre les offres privées et les services numériques proposés par l'Etat. Elle se matérialise par exemple par :
+          <strong>Cette coopération public/privé permet la pleine complémentarité</strong> entre les
+          offres privées et les services numériques proposés par l'Etat. Elle se matérialise par
+          exemple par :
         </p>
         <ul>
-          <li><strong>le raccordement des fournisseurs de services</strong> à la fédération ProConnect permettant d'authentifier les utilisateurs professionnels de manière sécurisée ;</li>
-          <li><strong>le référencement et la valorisation des services</strong> privés auprès des collectivités territoriales ;</li>
-          <li><strong>l'hébergement et l'intégration des logiciels libres</strong> pour le compte des structures publiques de mutualisation ;</li>
-          <li><strong>la contribution des équipes de développement aux mêmes logiciels libres ;</strong></li>
-          <li><strong>etc...</strong></li>
+          <li>
+            <strong>le raccordement des fournisseurs de services</strong> à la fédération ProConnect
+            permettant d'authentifier les utilisateurs professionnels de manière sécurisée ;
+          </li>
+          <li>
+            <strong>le référencement et la valorisation des services</strong> privés auprès des
+            collectivités territoriales ;
+          </li>
+          <li>
+            <strong>l'hébergement et l'intégration des logiciels libres</strong> pour le compte des
+            structures publiques de mutualisation ;
+          </li>
+          <li>
+            <strong>
+              la contribution des équipes de développement aux mêmes logiciels libres ;
+            </strong>
+          </li>
+          <li>
+            <strong>etc...</strong>
+          </li>
         </ul>
       </>
     ),
@@ -180,9 +223,22 @@ const FAQS = [
     question: <>Quelles sont les étapes pour devenir partenaire ?</>,
     answer: (
       <>
-        <p>Pour devenir partenaire de la Suite territoriale, les structures de mutualisation sont invitées à :</p>
+        <p>
+          Pour devenir partenaire de la Suite territoriale, les structures de mutualisation sont
+          invitées à :
+        </p>
         <ol>
-          <li>Contacter l'équipe à l'adresse <Link href="mailto:contact@suite.anct.gouv.fr" className={fr.cx("fr-link")} target="_blank" rel="noopener noreferrer">contact@suite.anct.gouv.fr</Link></li>
+          <li>
+            Contacter l'équipe à l'adresse{" "}
+            <Link
+              href="mailto:contact@suite.anct.gouv.fr"
+              className={fr.cx("fr-link")}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              contact@suite.anct.gouv.fr
+            </Link>
+          </li>
           <li>Formaliser leur volonté à travers un courrier d'intention ;</li>
           <li>Signer un contrat de partenariat public-public avec l'ANCT.</li>
         </ol>
@@ -194,16 +250,37 @@ const FAQS = [
     answer: (
       <>
         <p>
-          <strong>L'ANCT et ses partenaires publics s'engagent mutuellement pour une durée de trois ans à travers un contrat de partenariat public-public</strong> renouvelable. Ces contrats permettent la mutualisation des ressources en vue d'atteindre un objectif commun : sécuriser durablement les systèmes d'information et usages numériques des plus petites collectivités.
+          <strong>
+            L'ANCT et ses partenaires publics s'engagent mutuellement pour une durée de trois ans à
+            travers un contrat de partenariat public-public
+          </strong>{" "}
+          renouvelable. Ces contrats permettent la mutualisation des ressources en vue d'atteindre
+          un objectif commun : sécuriser durablement les systèmes d'information et usages numériques
+          des plus petites collectivités.
         </p>
         <p>
-          <strong>La démultiplication des partenaires publics, associés au sein d'une gouvernance commune, garantit la résilience du modèle.</strong> La coopération entre un opérateur de l'Etat et les opérateurs des territoires autour d'un objet commun est la principale garantie de maintien en condition opérationnelle et de pérennité des services numériques de la Suite territoriale.
+          <strong>
+            La démultiplication des partenaires publics, associés au sein d'une gouvernance commune,
+            garantit la résilience du modèle.
+          </strong>{" "}
+          La coopération entre un opérateur de l'Etat et les opérateurs des territoires autour d'un
+          objet commun est la principale garantie de maintien en condition opérationnelle et de
+          pérennité des services numériques de la Suite territoriale.
         </p>
         <p>
-          <strong>L'architecture technique décentralisée de la Suite territoriale</strong> et son déploiement par une fédération de partenaires est la principale garantie de sécurisation selon les critères de l'Agence nationale de la sécurité des systèmes d'information (ANSSI), partenaire du projet. Elle assure également l'indépendance des collectivités locales dans leurs propres choix techniques.
+          <strong>L'architecture technique décentralisée de la Suite territoriale</strong> et son
+          déploiement par une fédération de partenaires est la principale garantie de sécurisation
+          selon les critères de l'Agence nationale de la sécurité des systèmes d'information
+          (ANSSI), partenaire du projet. Elle assure également l'indépendance des collectivités
+          locales dans leurs propres choix techniques.
         </p>
         <p>
-          <strong>Les logiciels sont développés en open source, garantissant non seulement la transparence</strong> des investissements de l'Etat dans les services de la Suite territoriale, mais également leur libre appropriation et contribution par l'ensemble de l'écosystème : collectivités, structures de mutualisation, filière privée, états européens etc.
+          <strong>
+            Les logiciels sont développés en open source, garantissant non seulement la transparence
+          </strong>{" "}
+          des investissements de l'Etat dans les services de la Suite territoriale, mais également
+          leur libre appropriation et contribution par l'ensemble de l'écosystème : collectivités,
+          structures de mutualisation, filière privée, états européens etc.
         </p>
       </>
     ),
@@ -213,13 +290,24 @@ const FAQS = [
     answer: (
       <>
         <p>
-          <strong>La Suite territoriale et LaSuite numérique proposent toutes les deux des communs numériques simples et interopérables</strong>, mis à la disposition des professionnels de la sphère publique et accessibles via une authentification unique sécurisée ProConnect.
+          <strong>
+            La Suite territoriale et LaSuite numérique proposent toutes les deux des communs
+            numériques simples et interopérables
+          </strong>
+          , mis à la disposition des professionnels de la sphère publique et accessibles via une
+          authentification unique sécurisée ProConnect.
         </p>
         <p>
-          <strong>La Suite territoriale</strong> est un ensemble de services numériques opérés par l'Agence Nationale de Cohésion des Territoires (ANCT) et les partenaires des territoires. Elle s'adresse aux élus et agents publics des plus petites collectivités territoriales.
+          <strong>La Suite territoriale</strong> est un ensemble de services numériques opérés par
+          l'Agence Nationale de Cohésion des Territoires (ANCT) et les partenaires des territoires.
+          Elle s'adresse aux élus et agents publics des plus petites collectivités territoriales.
         </p>
         <p>
-          <Link href="https://lasuite.numerique.gouv.fr/" target="_blank" rel="noopener noreferrer">La suite</Link> numérique est un ensemble de services numériques mis à disposition par la Direction Interministérielle du Numérique (DINUM) aux agents de la fonction publique d'Etat.
+          <Link href="https://lasuite.numerique.gouv.fr/" target="_blank" rel="noopener noreferrer">
+            La suite
+          </Link>{" "}
+          numérique est un ensemble de services numériques mis à disposition par la Direction
+          Interministérielle du Numérique (DINUM) aux agents de la fonction publique d'Etat.
         </p>
       </>
     ),
@@ -229,21 +317,50 @@ const FAQS = [
     answer: (
       <>
         <p>
-          Le raccordement à la fédération d'identités numériques professionnelles ProConnect peut être réalisé en autonomie par tous les partenaires, publics comme privés. L'Espace Partenaires ProConnect permet de guider le raccordement :
+          Le raccordement à la fédération d'identités numériques professionnelles ProConnect peut
+          être réalisé en autonomie par tous les partenaires, publics comme privés. L'Espace
+          Partenaires ProConnect permet de guider le raccordement :
         </p>
         <ul>
           <li>
-            <Link href="https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite" target="_blank" rel="noopener noreferrer">En tant que Fournisseurs d'Identité</Link> pour les structures publiques de mutualisation qui disposent de leur propre annuaire d'utilisateurs professionnels ;
+            <Link
+              href="https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              En tant que Fournisseurs d'Identité
+            </Link>{" "}
+            pour les structures publiques de mutualisation qui disposent de leur propre annuaire
+            d'utilisateurs professionnels ;
           </li>
           <li>
-            <Link href="https://partenaires.proconnect.gouv.fr/docs/fournisseur-service" target="_blank" rel="noopener noreferrer">En tant que Fournisseurs de services</Link> pour les partenaires publics ou privés qui souhaitent intégrer ProConnect comme moyen d'authentification unique sécurisé.
+            <Link
+              href="https://partenaires.proconnect.gouv.fr/docs/fournisseur-service"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              En tant que Fournisseurs de services
+            </Link>{" "}
+            pour les partenaires publics ou privés qui souhaitent intégrer ProConnect comme moyen
+            d'authentification unique sécurisé.
           </li>
         </ul>
         <p>
-          <strong>ProConnect est une fédération opérée par l'Etat et la DINUM</strong> qui valide les demandes de raccordement <Link href="https://datapass.api.gouv.fr/demandes/pro_connect_identity_provider/nouveau" target="_blank" rel="noopener noreferrer">via Datapass</Link> et garantit le support technique.
+          <strong>ProConnect est une fédération opérée par l'Etat et la DINUM</strong> qui valide
+          les demandes de raccordement{" "}
+          <Link
+            href="https://datapass.api.gouv.fr/demandes/pro_connect_identity_provider/nouveau"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            via Datapass
+          </Link>{" "}
+          et garantit le support technique.
         </p>
         <p>
-          <strong>Dans le cadre de la Suite territoriale, l'ANCT déploie ProConnect</strong> auprès des collectivités en accompagnant le raccordement et la sécurisation des fournisseurs d'identité territoriaux.
+          <strong>Dans le cadre de la Suite territoriale, l'ANCT déploie ProConnect</strong> auprès
+          des collectivités en accompagnant le raccordement et la sécurisation des fournisseurs
+          d'identité territoriaux.
         </p>
       </>
     ),
@@ -275,7 +392,9 @@ const PartenairesPage: NextPage<PartenairesProps> = ({ regions, regionsDromSecti
                   textAlign: "center",
                 }}
               >
-                Les partenaires publics<br />de la Suite territoriale
+                Les partenaires publics
+                <br />
+                de la Suite territoriale
               </h1>
               <div className={fr.cx("fr-text--lg", "fr-mb-15v")}>{REF_INTRO}</div>
             </div>
@@ -305,60 +424,82 @@ const PartenairesPage: NextPage<PartenairesProps> = ({ regions, regionsDromSecti
                             gap: "0.3rem",
                           }}
                         >
-                          <h2 style={{ flex: 1, color: "var(--text-title-blue-france)" }}>{region.name}</h2>
+                          <h2 style={{ flex: 1, color: "var(--text-title-blue-france)" }}>
+                            {region.name}
+                          </h2>
                         </div>
                       }
                     >
-                      <ul className={fr.cx("fr-links-group", "fr-mb-0") + " partenaires-links-list"}>
-                        {region.id === "drom-region"
-                          ? regionsDromSections.map((dromRegion) => (
-                              <li
-                                key={`drom-${dromRegion.id}`}
-                                className="partenaires-drom-links-item"
-                              >
-                                <span><strong>{dromRegion.name}</strong></span>
-                                {dromRegion.items.length > 0 ? (
-                                  <ul className={fr.cx("fr-links-group", "fr-mb-0") + " partenaires-drom-links-list"}>
-                                    {dromRegion.items.map((item) => (
-                                      <li key={`${dromRegion.id}-${item.name}`} className="partenaires-drom-links-item">
-                                        <OpsnItem item={item} />
-                                      </li>
-                                    ))}
-                                  </ul>
-                                ) : (
-                                  <NoOpsnItem isDrom={true} />
-                                )}
-                              </li>
-                            ))
-                          : region.items.length > 0 ? (
-                              region.items.map((item) => (
-                                <li key={`${region.id}-${item.name}`} className="partenaires-links-item">
-                                  <OpsnItem item={item} />
-                                </li>
-                              ))
-                            ) : (
-                              <li className="partenaires-links-item">
-                                <NoOpsnItem isDrom={false} />
-                              </li>
-                            )}
+                      <ul
+                        className={fr.cx("fr-links-group", "fr-mb-0") + " partenaires-links-list"}
+                      >
+                        {region.id === "drom-region" ? (
+                          regionsDromSections.map((dromRegion) => (
+                            <li
+                              key={`drom-${dromRegion.id}`}
+                              className="partenaires-drom-links-item"
+                            >
+                              <span>
+                                <strong>{dromRegion.name}</strong>
+                              </span>
+                              {dromRegion.items.length > 0 ? (
+                                <ul
+                                  className={
+                                    fr.cx("fr-links-group", "fr-mb-0") +
+                                    " partenaires-drom-links-list"
+                                  }
+                                >
+                                  {dromRegion.items.map((item) => (
+                                    <li
+                                      key={`${dromRegion.id}-${item.name}`}
+                                      className="partenaires-drom-links-item"
+                                    >
+                                      <OpsnItem item={item} />
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : (
+                                <NoOpsnItem isDrom={true} />
+                              )}
+                            </li>
+                          ))
+                        ) : region.items.length > 0 ? (
+                          region.items.map((item) => (
+                            <li
+                              key={`${region.id}-${item.name}`}
+                              className="partenaires-links-item"
+                            >
+                              <OpsnItem item={item} />
+                            </li>
+                          ))
+                        ) : (
+                          <li className="partenaires-links-item">
+                            <NoOpsnItem isDrom={false} />
+                          </li>
+                        )}
                       </ul>
                     </Accordion>
                   </div>
                 </div>
               ))}
             </div>
-            <div id="declic" className={fr.cx("fr-p-4w", "fr-mt-9w")} style={{
-              border: "1px solid var(--border-default-grey)",
-              borderRadius: "16px",
-              backgroundColor: "#F5F5FE80",
-            }}>
+            <div
+              id="declic"
+              className={fr.cx("fr-p-4w", "fr-mt-9w")}
+              style={{
+                border: "1px solid var(--border-default-grey)",
+                borderRadius: "16px",
+                backgroundColor: "#F5F5FE80",
+              }}
+            >
               <Image src="/images/logo-declic.svg" alt="Déclic" width={275} height={53} />
               <p className={fr.cx("fr-mt-4w", "fr-mb-2w")}>
-                Déclic est la fédération des Opérateurs Publics de Services Numériques (OPSN). Ce réseau, exclusivement dévoué à l’intérêt général des collectivités, consiste à mutualiser l’information, les expériences, la veille technologique et réglementaire, par une mise en commun d’outils et de moyens.
+                Déclic est la fédération des Opérateurs Publics de Services Numériques (OPSN). Ce
+                réseau, exclusivement dévoué à l’intérêt général des collectivités, consiste à
+                mutualiser l’information, les expériences, la veille technologique et réglementaire,
+                par une mise en commun d’outils et de moyens.
               </p>
-              <Button
-                linkProps={{ href: "https://www.asso-declic.fr/" }}
-              >
+              <Button linkProps={{ href: "https://www.asso-declic.fr/" }}>
                 Voir l'intégralité du réseau
               </Button>
             </div>
@@ -390,21 +531,23 @@ export const getServerSideProps: GetServerSideProps<PartenairesProps> = async ()
     const regionsMetropolitaines = apiRegions.filter((region) => !getIsDrom(region.name));
     const dromSection = {
       id: `drom-region`,
-      name: 'Départements et régions d\'outre-mer',
+      name: "Départements et régions d'outre-mer",
       data: [],
-    }
+    };
     const regionsDrom = apiRegions.filter((region) => getIsDrom(region.name));
-    
-    const regions: RegionSection[] = [...regionsMetropolitaines, dromSection].map((region, idx) => ({
-      id: (region as { id?: string }).id ?? `region-${idx}`,
-      name: region.name,
-      items: region.data.map((r) => ({
-        name: r.name,
-        website: r.website ?? null,
-        status: r.status,
-        hasProConnect: r.hasProConnect ?? null,
-      })),
-    }));
+
+    const regions: RegionSection[] = [...regionsMetropolitaines, dromSection].map(
+      (region, idx) => ({
+        id: (region as { id?: string }).id ?? `region-${idx}`,
+        name: region.name,
+        items: region.data.map((r) => ({
+          name: r.name,
+          website: r.website ?? null,
+          status: r.status,
+          hasProConnect: r.hasProConnect ?? null,
+        })),
+      }),
+    );
 
     const regionsDromSections: RegionSection[] = regionsDrom.map((region, idx) => ({
       id: `drom-region-${idx}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment panels now only show services that are both used and configured as visible; when none apply, a “no service used” message appears. Service logos are shown only when available.

* **Style**
  * Various UI code and content formatting refinements, including minor text wording adjustments and internal reformatting for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->