### PR TITLE
✨(deploymap) remove regions and departments filters

### DIFF
--- a/src/components/map/features/deploiement/SidePanelContent.jsx
+++ b/src/components/map/features/deploiement/SidePanelContent.jsx
@@ -270,7 +270,7 @@ const SidePanelContent = ({ container, getColor, mapState, selectLevel, setMapSt
           </button>
           {openDropdown === 'structure' && (
             <ul className={styles.filterDropdownMenu}>
-              {[['all', 'Toutes structures'], ['commune', 'Communes'], ['epci', 'Intercommunalités'], ['department', 'Départements'], ['region', 'Région']].map(([val, label], index) => (
+              {[['all', 'Toutes structures'], ['commune', 'Communes'], ['epci', 'Intercommunalités']].map(([val, label], index) => (
                 <li
                   key={val}
                   className={`${styles.filterDropdownOption} ${index === 0 ? styles.filterDropdownOptionFirst : ''}`}
@@ -322,8 +322,8 @@ const serviceDetails = (service, stats, compact = false) => {
         <div className={styles.serviceDetailsGrid}>
           <span>Communes : <strong>{formatNumber(communes)}</strong></span>
           {showEpci && <span>EPCI : <strong>{formatNumber(epci)}</strong></span>}
-          {showDepartement && <span>Départements : <strong>{formatNumber(departements)}</strong></span>}
-          {showRegion && <span>Régions : <strong>{formatNumber(regions)}</strong></span>}
+          {/* {showDepartement && <span>Départements : <strong>{formatNumber(departements)}</strong></span>}
+          {showRegion && <span>Régions : <strong>{formatNumber(regions)}</strong></span>} */}
         </div>
       </div>
     );

--- a/src/components/map/features/deploiement/SidePanelContent.jsx
+++ b/src/components/map/features/deploiement/SidePanelContent.jsx
@@ -270,7 +270,7 @@ const SidePanelContent = ({ container, getColor, mapState, selectLevel, setMapSt
           </button>
           {openDropdown === 'structure' && (
             <ul className={styles.filterDropdownMenu}>
-              {[['all', 'Toutes structures'], ['commune', 'Communes'], ['epci', 'Intercommunalités']].map(([val, label], index) => (
+              {[['all', 'Toutes structures'], ['commune', 'Communes'], ['epci', 'Intercommunalités'], ['department', 'Départements'], ['region', 'Régions']].map(([val, label], index) => (
                 <li
                   key={val}
                   className={`${styles.filterDropdownOption} ${index === 0 ? styles.filterDropdownOptionFirst : ''}`}
@@ -322,8 +322,8 @@ const serviceDetails = (service, stats, compact = false) => {
         <div className={styles.serviceDetailsGrid}>
           <span>Communes : <strong>{formatNumber(communes)}</strong></span>
           {showEpci && <span>EPCI : <strong>{formatNumber(epci)}</strong></span>}
-          {/* {showDepartement && <span>Départements : <strong>{formatNumber(departements)}</strong></span>}
-          {showRegion && <span>Régions : <strong>{formatNumber(regions)}</strong></span>} */}
+          {showDepartement && departements > 0 && <span>Départements : <strong>{formatNumber(departements)}</strong></span>}
+          {showRegion && regions > 0 && <span>Régions : <strong>{formatNumber(regions)}</strong></span>}
         </div>
       </div>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Organization-type dropdown keeps the "Départements" option and now shows "Régions" (plural).
  * Service details grid: "Départements" and "Régions" count rows are displayed only when their computed counts are greater than zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/st-home/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->