### PR TITLE
✨(rpnt) allow some redirects to gouv sites in RPNT 1.6

### DIFF
--- a/data/tasks/check_website.py
+++ b/data/tasks/check_website.py
@@ -101,7 +101,7 @@ def check_website(url, force_http_url=None):
 def normalize_domain(netloc):
     """Lowercase a netloc and strip the default ports and a leading "www."."""
     netloc = netloc.lower()
-    netloc = re.sub(r"\:(80|443)", "", netloc)
+    netloc = re.sub(r":(80|443)$", "", netloc)
     netloc = re.sub(r"^www\.", "", netloc)
     return netloc
 
@@ -226,9 +226,7 @@ def check_non_www(base_final_domain, base_url, urls_to_test, issues, request_kwa
                     )
             else:
                 # Check if final domain matches original
-                final_domain = urlparse(response.url).netloc
-                final_domain = re.sub(r"\:(80|443)", "", final_domain)
-                final_domain = re.sub(r"^www\.", "", final_domain)
+                final_domain = normalize_domain(urlparse(response.url).netloc)
                 if final_domain != base_final_domain:
                     if url_type == "http_no_www":
                         issues[Issues.WEBSITE_HTTP_NOWWW] = (

--- a/data/tasks/check_website.py
+++ b/data/tasks/check_website.py
@@ -11,6 +11,7 @@ from celery_app import app
 
 from .conformance import Issues, data_checks_doable, validate_conformance
 from .db import find_org_by_siret, list_all_orgs, upsert_issues
+from .defs import WEBSITE_REDIRECT_DOMAINS_ALLOWED, WEBSITE_REDIRECT_MAX_HOPS
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -97,6 +98,42 @@ def check_website(url, force_http_url=None):
     return issues
 
 
+def normalize_domain(netloc):
+    """Lowercase a netloc and strip the default ports and a leading "www."."""
+    netloc = netloc.lower()
+    netloc = re.sub(r"\:(80|443)", "", netloc)
+    netloc = re.sub(r"^www\.", "", netloc)
+    return netloc
+
+
+def is_allowed_redirect_domain(domain):
+    """
+    Whether a website may redirect to (or through) `domain` without breaking RPNT
+    criterion 1.6. Matches the allow-listed domains and any of their subdomains.
+    """
+    domain = normalize_domain(domain)
+    return any(
+        domain == allowed or domain.endswith("." + allowed)
+        for allowed in WEBSITE_REDIRECT_DOMAINS_ALLOWED
+    )
+
+
+def is_trusted_redirect_chain(response, expected_domain):
+    """
+    Whether the redirect chain that produced `response` stayed within trusted
+    domains (the expected domain or an allow-listed one, see is_allowed_redirect_domain)
+    across at most WEBSITE_REDIRECT_MAX_HOPS hops. This keeps RPNT criterion 1.6 valid
+    when a declared site redirects to — or bounces through — collectivite.fr or *.gouv.fr.
+    """
+    if len(response.history) > WEBSITE_REDIRECT_MAX_HOPS:
+        return False
+    for hop in [*response.history, response]:
+        domain = normalize_domain(urlparse(hop.url).netloc)
+        if domain != expected_domain and not is_allowed_redirect_domain(domain):
+            return False
+    return True
+
+
 def check_http(base_url, urls_to_test, issues, request_kwargs):
     """
     Check HTTP URL
@@ -118,11 +155,11 @@ def check_http(base_url, urls_to_test, issues, request_kwargs):
                 issues[Issues.WEBSITE_HTTP_REDIRECT] = f"Site stays on HTTP: {http_response.url}"
 
             # Check if final domain matches original
-            expected_domain = re.sub(r"^www\.", "", urlparse(urls_to_test["https"]).netloc)
-            final_domain = urlparse(http_response.url).netloc
-            final_domain = re.sub(r"\:(80|443)", "", final_domain)
-            final_domain = re.sub(r"^www\.", "", final_domain)
-            if final_domain != expected_domain:
+            expected_domain = normalize_domain(urlparse(urls_to_test["https"]).netloc)
+            final_domain = normalize_domain(urlparse(http_response.url).netloc)
+            if final_domain != expected_domain and not is_trusted_redirect_chain(
+                http_response, expected_domain
+            ):
                 issues[Issues.WEBSITE_DOMAIN_REDIRECT] = (
                     f"HTTP Site redirects to different domain: {final_domain} vs. {expected_domain}"
                 )
@@ -149,11 +186,11 @@ def check_https(base_url, urls_to_test, issues, request_kwargs):
             issues[Issues.WEBSITE_DOWN] = f"HTTPS returned status {https_response.status_code}"
         else:
             # Check if final domain matches original
-            expected_domain = re.sub(r"^www\.", "", urlparse(urls_to_test["https"]).netloc)
-            final_domain = urlparse(https_response.url).netloc
-            final_domain = re.sub(r"\:(80|443)", "", final_domain)
-            final_domain = re.sub(r"^www\.", "", final_domain)
-            if final_domain != expected_domain:
+            expected_domain = normalize_domain(urlparse(urls_to_test["https"]).netloc)
+            final_domain = normalize_domain(urlparse(https_response.url).netloc)
+            if final_domain != expected_domain and not is_trusted_redirect_chain(
+                https_response, expected_domain
+            ):
                 issues[Issues.WEBSITE_DOMAIN_REDIRECT] = (
                     f"HTTPS Site redirects to different domain: {final_domain} vs. {expected_domain}"
                 )

--- a/data/tasks/defs.py
+++ b/data/tasks/defs.py
@@ -120,6 +120,19 @@ DOMAIN_EXTENSIONS_ALLOWED = [
     # "mf",  # Saint-Martin
 ]
 
+# Domains a declared website is allowed to redirect to — as a final target or as
+# an intermediary step — without breaking RPNT criterion 1.6 ("the site declared
+# on Service-Public.gouv.fr must not redirect elsewhere"). Subdomains are included.
+WEBSITE_REDIRECT_DOMAINS_ALLOWED = [
+    "collectivite.fr",
+    "gouv.fr",
+]
+
+# Maximum number of redirects tolerated in a trusted chain (criterion 1.6): a
+# declared site may bounce through the allow-listed domains above, but only if the
+# whole chain stays trusted and is no longer than this many hops.
+WEBSITE_REDIRECT_MAX_HOPS = 5
+
 EU_COUNTRIES = {
     "AT",
     "BE",

--- a/data/tests/test_check_website.py
+++ b/data/tests/test_check_website.py
@@ -8,7 +8,11 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import pytest
 import requests
 
-from ..tasks.check_website import check_website
+from ..tasks.check_website import (
+    check_website,
+    is_allowed_redirect_domain,
+    is_trusted_redirect_chain,
+)
 from ..tasks.conformance import Issues
 
 
@@ -32,7 +36,18 @@ class LocalhostHandler(BaseHTTPRequestHandler):
 
         elif self.path == "/domain_redirect":
             self.send_response(302)
+            self.send_header("Location", "https://example.com/")
+            self.end_headers()
+
+        elif self.path == "/gouv_redirect":
+            self.send_response(302)
             self.send_header("Location", "https://suiteterritoriale.anct.gouv.fr")
+            self.end_headers()
+
+        elif self.path == "/double_gouv_redirect":
+            # Multi-hop: localhost -> localhost -> *.gouv.fr (a trusted chain)
+            self.send_response(302)
+            self.send_header("Location", "/gouv_redirect")
             self.end_headers()
 
         elif self.path == "/slow":
@@ -216,9 +231,96 @@ def test_https_redirect(http_server):
 
 
 def test_domain_redirect(http_server):
-    """Test detection of domain redirect"""
+    """A redirect to a non-allowed domain breaks criterion 1.6"""
     issues = check_website("http://localhost:8080/domain_redirect")
     assert Issues.WEBSITE_DOMAIN_REDIRECT in issues
+
+
+def test_allowed_redirect_gouv(http_server):
+    """A redirect to a *.gouv.fr domain is on the allow-list (criterion 1.6)"""
+    issues = check_website("http://localhost:8080/gouv_redirect")
+    assert Issues.WEBSITE_DOMAIN_REDIRECT not in issues
+
+
+def test_allowed_multihop_redirect(http_server):
+    """A multi-hop chain that stays trusted and ends on *.gouv.fr is allowed"""
+    issues = check_website("http://localhost:8080/double_gouv_redirect")
+    assert Issues.WEBSITE_DOMAIN_REDIRECT not in issues
+
+
+@pytest.mark.parametrize(
+    "domain,allowed",
+    [
+        ("collectivite.fr", True),
+        ("www.collectivite.fr", True),
+        ("mairie-de-test.collectivite.fr", True),
+        ("gouv.fr", True),
+        ("suiteterritoriale.anct.gouv.fr", True),
+        ("www.sante.gouv.fr", True),
+        ("example.com", False),
+        ("maville.com", False),
+        ("notcollectivite.fr", False),  # not a subdomain, must not match
+        ("collectivite.fr.evil.com", False),  # allow-listed name as a prefix
+        ("evil-gouv.fr", False),
+        ("gouv.fr.evil.com", False),
+    ],
+)
+def test_is_allowed_redirect_domain(domain, allowed):
+    assert is_allowed_redirect_domain(domain) is allowed
+
+
+class _FakeResponse:
+    """Minimal stand-in for a requests.Response redirect chain."""
+
+    def __init__(self, url, history=None):
+        self.url = url
+        self.history = history or []
+
+
+def _chain(*urls):
+    """Build a fake response whose history is every url but the last."""
+    *history_urls, final_url = urls
+    return _FakeResponse(final_url, [_FakeResponse(u) for u in history_urls])
+
+
+def test_trusted_redirect_chain_to_allowed_target():
+    chain = _chain("https://mairie-test.fr/", "https://suiteterritoriale.anct.gouv.fr/")
+    assert is_trusted_redirect_chain(chain, "mairie-test.fr") is True
+
+
+def test_trusted_redirect_chain_through_allowed_intermediary():
+    chain = _chain(
+        "https://mairie-test.fr/",
+        "https://www.collectivite.fr/login",
+        "https://mairie-test.collectivite.fr/",
+    )
+    assert is_trusted_redirect_chain(chain, "mairie-test.fr") is True
+
+
+def test_untrusted_intermediary_breaks_chain():
+    chain = _chain(
+        "https://mairie-test.fr/",
+        "https://tracker.example/redir",
+        "https://suiteterritoriale.anct.gouv.fr/",
+    )
+    assert is_trusted_redirect_chain(chain, "mairie-test.fr") is False
+
+
+def test_untrusted_target_breaks_chain():
+    chain = _chain("https://mairie-test.fr/", "https://example.com/")
+    assert is_trusted_redirect_chain(chain, "mairie-test.fr") is False
+
+
+def test_trusted_chain_within_hop_limit():
+    # 5 redirects (6 urls) all trusted -> still allowed
+    chain = _chain(*(["https://mairie-test.fr/"] + ["https://x.gouv.fr/"] * 5))
+    assert is_trusted_redirect_chain(chain, "mairie-test.fr") is True
+
+
+def test_trusted_chain_exceeding_hop_limit():
+    # 6 redirects (7 urls) all trusted -> too long, not allowed
+    chain = _chain(*(["https://mairie-test.fr/"] + ["https://x.gouv.fr/"] * 6))
+    assert is_trusted_redirect_chain(chain, "mairie-test.fr") is False
 
 
 def test_ssl_error():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Website validation now supports trusted redirect chains to pre-approved domains with a maximum of 5 hops per chain

## Bug Fixes
* Enhanced domain mismatch detection during website validation to properly handle legitimate redirect chains while preventing suspicious multi-hop redirects

## Tests
* Added comprehensive tests validating redirect allowlist matching and redirect chain trust verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/st-home/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->