### PR TITLE
🔧(caddy) make geoip download fatal & expect a raw mmdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ data-lint-check:  ## Check data code linting without fixing
 .PHONY: data-lint-check
 
 data-geoip-download:  ## Download the GeoIP database from https://www.npmjs.com/package/@ip-location-db/dbip-geo-whois-asn-country-mmdb
-	mkdir -p data/dumps && curl -LSs -o data/dumps/geoip-country.mmdb 'https://cdn.jsdelivr.net/npm/@ip-location-db/dbip-geo-whois-asn-country-mmdb/dbip-geo-whois-asn-country-ipv4.mmdb'
+	mkdir -p data/dumps && curl -fLSs -o data/dumps/geoip-country.mmdb 'https://cdn.jsdelivr.net/npm/@ip-location-db/dbip-geo-whois-asn-country-mmdb/dbip-geo-whois-asn-country-ipv4.mmdb'
 .PHONY: data-geoip-download
 
 # ==============================================================================

--- a/scripts/scalingo_postfrontend
+++ b/scripts/scalingo_postfrontend
@@ -13,6 +13,11 @@ make data-geoip-download
 # is simply disabled.
 if [ -n "${PROXY_GEOIP_DB_URL}" ]; then
   echo "-----> Downloading GeoIP database for Caddy"
+  if [ -z "${PROXY_GEOIP_DB_PATH}" ]; then
+    echo "ERROR: PROXY_GEOIP_DB_PATH must be set when PROXY_GEOIP_DB_URL is set" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "data/${PROXY_GEOIP_DB_PATH}")"
   curl -fLSs -o "data/${PROXY_GEOIP_DB_PATH}" "${PROXY_GEOIP_DB_URL}"
 fi
 

--- a/scripts/scalingo_postfrontend
+++ b/scripts/scalingo_postfrontend
@@ -7,18 +7,13 @@ echo "-----> Running post-frontend script"
 
 make data-geoip-download
 
-echo "-----> Downloading GeoIP database for Caddy"
-# Non-fatal: a bad/unreachable PROXY_GEOIP_DB_URL must NOT fail the deploy. If the
-# download fails the .mmdb is simply absent and scalingo_run_web disables geo-
-# blocking (fail open) instead of letting Caddy refuse to boot. The `if` condition
-# suspends `errexit` for these commands.
-if [ -n "${PROXY_GEOIP_DB_URL}" ] \
-  && curl -fLSs -o /tmp/caddy-geoip.mmdb.gz "${PROXY_GEOIP_DB_URL}" \
-  && gunzip -f /tmp/caddy-geoip.mmdb.gz; then
-  mv /tmp/caddy-geoip.mmdb "data/${PROXY_GEOIP_DB_PATH}"
-else
-  echo "WARNING: GeoIP database download failed or PROXY_GEOIP_DB_URL unset; geo-blocking will be disabled"
-  rm -f /tmp/caddy-geoip.mmdb.gz
+# Optional geo-blocking: PROXY_GEOIP_DB_URL must point to a raw .mmdb in GeoLite2
+# schema (country.iso_code). When set, a failed download fails the deploy (errexit)
+# — better than silently deploying without geo-blocking. When unset, geo-blocking
+# is simply disabled.
+if [ -n "${PROXY_GEOIP_DB_URL}" ]; then
+  echo "-----> Downloading GeoIP database for Caddy"
+  curl -fLSs -o "data/${PROXY_GEOIP_DB_PATH}" "${PROXY_GEOIP_DB_URL}"
 fi
 
 mv data/* .

--- a/scripts/scalingo_run_web
+++ b/scripts/scalingo_run_web
@@ -17,7 +17,7 @@ fi
 
 # Geo-blocking (empty country list or missing DB = disabled). The maxmind module
 # fails to boot if the .mmdb file is absent, so we only wire it up when the DB is
-# actually present — a failed/missing GeoIP download must not take Caddy down.
+# actually present (i.e. PROXY_GEOIP_DB_URL was set at deploy time).
 if [ -n "$PROXY_ALLOWED_COUNTRIES" ] && [ -f "$PROXY_GEOIP_DB_PATH" ]; then
   cat > geoblock.caddy <<EOF
 @geoblocked not maxmind_geolocation {

--- a/src/caddy/Caddyfile
+++ b/src/caddy/Caddyfile
@@ -6,8 +6,10 @@
 #                           e.g. "1.2.3.4 5.6.7.0/24"
 #   PROXY_ALLOWED_COUNTRIES — space-separated country codes to allow (empty = open)
 #                           e.g. "FR DE BE"
-#   PROXY_GEOIP_DB_PATH   — path to the MaxMind/DB-IP mmdb file (geo-blocking is
-#                           skipped — fail open — when this file is missing)
+#   PROXY_GEOIP_DB_PATH   — path to the MaxMind/DB-IP mmdb file (downloaded at
+#                           deploy time by scalingo_postfrontend when
+#                           PROXY_GEOIP_DB_URL is set; a failed download fails
+#                           the deploy)
 #   PROXY_RATE_LIMIT_EVENTS     — max requests per IP per window (empty = no rate limiting)
 #   PROXY_RATE_LIMIT_WINDOW     — rate limit window duration (default: 10s)
 
@@ -49,8 +51,7 @@
 
 		# Geo-blocking (generated at runtime by scalingo_run_web; empty file when
 		# disabled or when the GeoIP DB is missing). Generated rather than inline
-		# because the maxmind module fails to boot if the .mmdb file is absent —
-		# we don't want a failed DB download to take Caddy (and the deploy) down.
+		# because the maxmind module fails to boot if the .mmdb file is absent.
 		import geoblock.caddy
 
 		# Reverse proxy to Next.js


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GeoIP `.mmdb` downloads now fail on HTTP errors instead of proceeding silently.
  * Deployments no longer continue when the configured GeoIP database cannot be downloaded.
  * Geo-blocking configuration is only enabled when the GeoIP database is available at deploy time.
* **Documentation**
  * Updated GeoIP/MaxMind wiring notes to reflect the new “fail deploy if download fails” behavior and why geo-blocking is generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->